### PR TITLE
Add mutate method for interactive calls

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -42,7 +42,5 @@ setInterval(() => {
   morbidoTarget.appendChild(p);
   while (i-- > 0) morbidoTarget.appendChild(p.cloneNode(true));
 
-  debugger;
-
   morbido.mutate();
 }, 3000);

--- a/example/example.js
+++ b/example/example.js
@@ -2,7 +2,6 @@ import 'regenerator-runtime/runtime';
 import Morbido from '../src/index';
 
 const morbidoTarget = document.getElementById('morbido-target');
-const changingParagraph = document.getElementById('changing-paragraph');
 
 const morbido = new Morbido(morbidoTarget, {
   onExit: ({ mutation, exitingElement, enteringElement }) => {
@@ -22,21 +21,28 @@ const morbido = new Morbido(morbidoTarget, {
     return new Promise(resolve => setTimeout(resolve, 600));
   },
 });
-morbido.watch();
 
 const DUMMY_PARAGRAPH =
   'Forte, frittata tortellini paparazzi caprese, forte, cupola zucchini\
 pronto tombola caprese salami. Spaghetti confetti ballerina cannelloni\
 tortellini spaghetti espresso, ciao panini pepperoni ballerina\
-zucchini gnocchi pepperoni, barista gnocchi mamma salami frittata\
+zucchini gnocchi pepperoni, barista <strong>gnocchi mamma</strong> salami frittata\
 pepperoni.';
 
 let pCount = 0;
 setInterval(() => {
   pCount = (pCount + 1) % 3;
-  let i = pCount + 1;
-  let p = '';
-  while (i-- > 0) p += ' ' + DUMMY_PARAGRAPH;
+  let i = pCount;
 
-  changingParagraph.innerText = p;
+  Array.from(morbidoTarget.querySelectorAll('p')).forEach(p => p.remove());
+
+  const p = document.createElement('p');
+  p.innerHTML = DUMMY_PARAGRAPH;
+
+  morbidoTarget.appendChild(p);
+  while (i-- > 0) morbidoTarget.appendChild(p.cloneNode(true));
+
+  debugger;
+
+  morbido.mutate();
 }, 3000);

--- a/example/index.html
+++ b/example/index.html
@@ -26,6 +26,7 @@
         </p>
       </div>
     </div>
+    <div class="the-next-one">🧸</div>
 
     <script src="/dist/example.js"></script>
   </body>

--- a/example/style.css
+++ b/example/style.css
@@ -7,6 +7,7 @@ html {
 }
 body {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 
@@ -18,12 +19,16 @@ body {
   line-height: 1.6em;
 }
 
+* {
+  box-sizing: border-box;
+}
+
 .wrapper {
   width: 100%;
   max-width: 64rem;
   margin: 0 auto;
   position: relative;
-  outline: 2px dashed magenta;
+  outline: 2px dashed #e66488;
 }
 
 .morbido-target {
@@ -35,6 +40,12 @@ body {
   opacity: 0;
 }
 
-* {
-  box-sizing: border-box;
+.the-next-one {
+  width: 100%;
+  max-width: 64rem;
+  margin-top: 3rem;
+
+  font-size: 6.4rem;
+  line-height: 1.3em;
+  text-align: center;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,8 @@ export default class Morbido {
     this._target = el;
     this._wrapper = this._target.parentNode;
 
+    this._saveCurrentState();
+
     this._isWatching = false;
     this._mutationObserver = new MutationObserver(this._handleMutation);
     this._isMutating = false;
@@ -59,9 +61,8 @@ export default class Morbido {
       height: this._target.offsetHeight,
     };
   }
-  _handleMutation = async mutationsList => {
-    this._mutationObserver.disconnect();
 
+  async _mutate() {
     this._wrapper = this._target.parentNode;
 
     this._mutation = {
@@ -130,6 +131,12 @@ export default class Morbido {
     ]);
 
     this._saveCurrentState();
+  }
+
+  _handleMutation = async () => {
+    this._mutationObserver.disconnect();
+
+    await this._mutate();
 
     this._mutationObserver.observe(this._target, this._getObserverOptions());
   };
@@ -161,5 +168,13 @@ export default class Morbido {
     this._isWatching = false;
 
     return true;
+  }
+
+  mutate() {
+    if (!this._isWatching) {
+      this._mutate();
+    } else {
+      console.warn('Warning: mutate has been called in watching mode.');
+    }
   }
 }


### PR DESCRIPTION
This method is useful when the user wants to manually activate the mutation instead of relying on watch.

Eg. the user makes multiple mutations in the same execution then call `mutate()`