### PR TITLE
Add "git add" action in lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   },
   "lint-staged": {
     "*.{js,css,md}": [
-      "prettier --write"
+      "prettier --write",
+      "git add"
     ]
   }
 }


### PR DESCRIPTION
The result of prettier wasn't added to the stage, and since lint-staged is executed on pre-commit the changes weren't included in the commit.